### PR TITLE
Fixed "file not found" error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,6 @@
+wget http://raw.githubusercontent.com/illinoisjackson/even-better-ls/master/ls_colors_generator.py
 chmod 777 ls_colors_generator.py
-sudo cp ls_colors_generator.py /usr/bin/ls_colors_generator
+sudo mv ls_colors_generator.py /usr/bin/ls_colors_generator
 wget http://ftp.gnu.org/gnu/coreutils/coreutils-8.2.tar.xz
 tar -xf coreutils-8.2.tar.xz
 rm coreutils-8.2.tar.xz


### PR DESCRIPTION
The current version of the script requires the user to download `ls_colors_generator.py` beforehand.
Also, using `cp` instead of `mv` leaves the leftover `ls_colors_generator.py` file (so we just move it instead of copying and removing).