### PR TITLE
Correct install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ GNU coreutils ls is 4709 lines long. Pairing it with its includes rises the line
 Side note: vdir and dir are also compiled during this process. Feel free to move them as well.
 
 ```
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/illinoisjackson/even-better-ls/master/install.sh")
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/illinoisjackson/even-better-ls/master/install.sh)"
 ```
 
 Additionally, one should append the contents of [append_to_profile.sh](https://raw.githubusercontent.com/illinoisjackson/even-better-ls/master/append_to_profile.sh) to their corresponding profile file (.zshrc, .bashrc).


### PR DESCRIPTION
Double quotes were in the wrong location.