### PR TITLE
Fix colour and add icon for Ruby

### DIFF
--- a/ls_colors_generator.py
+++ b/ls_colors_generator.py
@@ -821,7 +821,7 @@ def get_colors():
 		".pi":			cc(7, -1, 0xF10B),
 		".plt":			cc(7, -1, 0xF10B),
 		".pm":			cc(7, -1, 0xF10B),
-		".rb":			cc(7, -1, 0xF10B),
+		".rb":			cc(1, -1, 0xE739),
 		".rdf":			cc(7, -1, 0xF10B),
 		".rst":			cc(7, -1, 0xF10B),
 		".ru":			cc(7, -1, 0xF10B),


### PR DESCRIPTION
This uses the [Ruby](http://vorillaz.github.io/devicons/#/singleicon/ruby) icon and colours it red.